### PR TITLE
upgrade omnipay/common from 2.0 to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - hhvm
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - composer install -n --dev --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,8 @@
         "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~3.0"
+        "omnipay/tests": "~3.0",
+        "phpunit/phpunit": "^5.2|^6.5",
+        "squizlabs/php_codesniffer": "^3.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "psr-4": { "Omnipay\\PayZen\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "~3.0"
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -20,7 +20,7 @@ class PurchaseRequest extends AbstractRequest
         $data['vads_ctx_mode'] = $this->getTestMode() ? 'TEST' : 'PRODUCTION';
         $data['vads_trans_id'] = $this->getTransactionId();
         $data['vads_trans_date'] = $this->getTransactionDate();
-        $data['vads_amount'] = $this->getAmount();
+        $data['vads_amount'] = str_replace('.', '', $this->getAmount());
         $data['vads_currency'] = $this->getCurrencyNumeric();
         $data['vads_action_mode'] = 'INTERACTIVE';
         $data['vads_page_action'] = 'PAYMENT';

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -18,7 +18,7 @@ class GatewayTest extends GatewayTestCase
         $request = $this->gateway->purchase(array('amount' => '10.00'));
 
         $this->assertInstanceOf('Omnipay\PayZen\Message\PurchaseRequest', $request);
-        $this->assertSame('1000', $request->getAmount());
+        $this->assertSame('10.00', $request->getAmount());
     }
 
     public function testCompletePurchase()
@@ -26,7 +26,7 @@ class GatewayTest extends GatewayTestCase
         $request = $this->gateway->completePurchase(array('amount' => '10.00'));
 
         $this->assertInstanceOf('Omnipay\PayZen\Message\CompletePurchaseRequest', $request);
-        $this->assertSame('1000', $request->getAmount());
+        $this->assertSame('10.00', $request->getAmount());
     }
 
 }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -33,7 +33,7 @@ class PurchaseRequestTest extends TestCase
     {
         $data = $this->request->getData();
 
-        $this->assertSame('1524', $data['vads_amount']);
+        $this->assertSame('15.24', $data['vads_amount']);
         $this->assertSame('12345678', $data['vads_site_id']);
         $this->assertSame('978', $data['vads_currency']);
         $this->assertSame('INTERACTIVE', $data['vads_action_mode']);
@@ -48,6 +48,6 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://cancel', $data['vads_url_cancel']);
         $this->assertSame('http://error', $data['vads_url_error']);
         $this->assertSame('http://refused', $data['vads_url_refused']);
-        $this->assertSame('1e44c55b059db1b4d1b704d0bcede1fc273add9b', $data['signature']);
+        $this->assertSame('aedab7495c54ff978d901d5bdc22deed9f60df6e', $data['signature']);
     }
 }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -33,7 +33,7 @@ class PurchaseRequestTest extends TestCase
     {
         $data = $this->request->getData();
 
-        $this->assertSame('15.24', $data['vads_amount']);
+        $this->assertSame('1524', $data['vads_amount']);
         $this->assertSame('12345678', $data['vads_site_id']);
         $this->assertSame('978', $data['vads_currency']);
         $this->assertSame('INTERACTIVE', $data['vads_action_mode']);
@@ -48,6 +48,6 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://cancel', $data['vads_url_cancel']);
         $this->assertSame('http://error', $data['vads_url_error']);
         $this->assertSame('http://refused', $data['vads_url_refused']);
-        $this->assertSame('aedab7495c54ff978d901d5bdc22deed9f60df6e', $data['signature']);
+        $this->assertSame('1e44c55b059db1b4d1b704d0bcede1fc273add9b', $data['signature']);
     }
 }


### PR DESCRIPTION
I can't make it work with newer version of omnipay/common, required as omnipay 2.0 uses old versions of many dependencies.