### PR TITLE
WIP: Allows to define vads_page_action and vads_identifier_status

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -10,6 +10,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     const PAYMENT_CONFIG_SINGLE = 'SINGLE';
     const PAYMENT_CONFIG_MULTIPLE = 'MULTIPLE';
 
+    const PAGE_ACTION_PAYMENT = 'PAYMENT';
+    const PAGE_ACTION_ASK_REGISTER_PAY = 'ASK_REGISTER_PAY';
+
     public function getMerchantId()
     {
         return $this->getParameter('merchantId');
@@ -108,6 +111,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function setReturnMode($value)
     {
         return $this->setParameter('returnMode', $value);
+    }
+
+    public function getPageAction()
+    {
+        return $this->getParameter('pageAction');
+    }
+
+    public function setPageAction($value)
+    {
+        $this->setParameter('pageAction', $value);
     }
 
     public function setPaymentCards($value)

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -13,6 +13,12 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     const PAGE_ACTION_PAYMENT = 'PAYMENT';
     const PAGE_ACTION_ASK_REGISTER_PAY = 'ASK_REGISTER_PAY';
 
+    const IDENTIFIER_STATUS_CREATED = 'CREATED';
+    const IDENTIFIER_STATUS_NOT_CREATED = 'NOT_CREATED';
+    const IDENTIFIER_STATUS_UPDATED = 'UPDATED';
+    const IDENTIFIER_STATUS_NOT_UPDATED = 'NOT_UPDATED';
+    const IDENTIFIER_STATUS_ABANDONED = 'ABANDONED';
+
     public function getMerchantId()
     {
         return $this->getParameter('merchantId');
@@ -121,6 +127,26 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function setPageAction($value)
     {
         $this->setParameter('pageAction', $value);
+    }
+
+    public function getIdentifierStatus()
+    {
+        return $this->getParameter('identifierStatus');
+    }
+
+    public function setIdentifierStatus($value)
+    {
+        $this->setParameter('identifierStatus', $value);
+    }
+
+    public function getIdentifier()
+    {
+        return $this->getParameter('identifier');
+    }
+
+    public function setIdentifier($value)
+    {
+        $this->setParameter('identifier', $value);
     }
 
     public function setPaymentCards($value)

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -7,6 +7,8 @@ namespace Omnipay\PayZen\Message;
  */
 abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
+    const PAYMENT_CONFIG_SINGLE = 'SINGLE';
+    const PAYMENT_CONFIG_MULTIPLE = 'MULTIPLE';
 
     public function getMerchantId()
     {
@@ -116,6 +118,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function getPaymentCards()
     {
         return $this->getParameter('paymentCards');
+    }
+
+    public function setPaymentConfig($value)
+    {
+        $this->setParameter('paymentConfig', $value);
+    }
+
+    public function getPaymentConfig()
+    {
+        return $this->getParameter('paymentConfig');
     }
 
     public function setOrderId($value)

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -24,6 +24,8 @@ class PurchaseRequest extends AbstractRequest
         $data['vads_currency'] = $this->getCurrencyNumeric();
         $data['vads_action_mode'] = 'INTERACTIVE';
         $data['vads_page_action'] = $this->getPageAction() ?: self::PAGE_ACTION_PAYMENT;
+        $data['vads_identifier'] = $this->getIdentifier();
+        $data['vads_identifier_status'] = $this->getIdentifierStatus();
         $data['vads_version'] = 'V2';
         $data['vads_payment_config'] = $this->getPaymentConfig() ?: self::PAYMENT_CONFIG_SINGLE;
         $data['vads_capture_delay'] = 0;

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -25,7 +25,7 @@ class PurchaseRequest extends AbstractRequest
         $data['vads_action_mode'] = 'INTERACTIVE';
         $data['vads_page_action'] = 'PAYMENT';
         $data['vads_version'] = 'V2';
-        $data['vads_payment_config'] = 'SINGLE';
+        $data['vads_payment_config'] = $this->getPaymentConfig() ?: self::PAYMENT_CONFIG_SINGLE;
         $data['vads_capture_delay'] = 0;
         $data['vads_validation_mode'] = 0;
         $data['vads_url_success'] = $this->getSuccessUrl();

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -23,7 +23,7 @@ class PurchaseRequest extends AbstractRequest
         $data['vads_amount'] = str_replace('.', '', $this->getAmount());
         $data['vads_currency'] = $this->getCurrencyNumeric();
         $data['vads_action_mode'] = 'INTERACTIVE';
-        $data['vads_page_action'] = 'PAYMENT';
+        $data['vads_page_action'] = $this->getPageAction() ?: self::PAGE_ACTION_PAYMENT;
         $data['vads_version'] = 'V2';
         $data['vads_payment_config'] = $this->getPaymentConfig() ?: self::PAYMENT_CONFIG_SINGLE;
         $data['vads_capture_delay'] = 0;

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -50,4 +50,15 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://refused', $data['vads_url_refused']);
         $this->assertSame('aded095acd32a157a501c63986ac83e3fca0f377', $data['signature']);
     }
+
+    public function testGetDataWithCustomData()
+    {
+        $this->request->setPaymentConfig('MULTIPLE');
+        $this->request->setPageAction('ASK_REGISTER_PAY');
+
+        $data = $this->request->getData();
+
+        $this->assertSame('MULTIPLE', $data['vads_payment_config']);
+        $this->assertSame('ASK_REGISTER_PAY', $data['vads_page_action']);
+    }
 }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -48,17 +48,21 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://cancel', $data['vads_url_cancel']);
         $this->assertSame('http://error', $data['vads_url_error']);
         $this->assertSame('http://refused', $data['vads_url_refused']);
-        $this->assertSame('aded095acd32a157a501c63986ac83e3fca0f377', $data['signature']);
+        $this->assertSame('2e8566261b46ea6081859a7af0ada9e1578debb8', $data['signature']);
     }
 
     public function testGetDataWithCustomData()
     {
-        $this->request->setPaymentConfig('MULTIPLE');
-        $this->request->setPageAction('ASK_REGISTER_PAY');
+        $this->request->setPaymentConfig(AbstractRequest::PAYMENT_CONFIG_MULTIPLE);
+        $this->request->setPageAction(AbstractRequest::PAGE_ACTION_ASK_REGISTER_PAY);
+        $this->request->setIdentifier('123456');
+        $this->request->setIdentifierStatus(AbstractRequest::IDENTIFIER_STATUS_CREATED);
 
         $data = $this->request->getData();
 
-        $this->assertSame('MULTIPLE', $data['vads_payment_config']);
-        $this->assertSame('ASK_REGISTER_PAY', $data['vads_page_action']);
+        $this->assertSame(AbstractRequest::PAYMENT_CONFIG_MULTIPLE, $data['vads_payment_config']);
+        $this->assertSame(AbstractRequest::PAGE_ACTION_ASK_REGISTER_PAY, $data['vads_page_action']);
+        $this->assertSame('123456', $data['vads_identifier']);
+        $this->assertSame(AbstractRequest::IDENTIFIER_STATUS_CREATED, $data['vads_identifier_status']);
     }
 }


### PR DESCRIPTION
Needs https://github.com/ubitransports/omnipay-payzen/pull/3 first to be merged.

We needed to pass `vads_page_action` and `vads_identifier_status` in order to use the payment card remember feature. So we dynamized/added these parameters.

Also an unit test is added to test custom parameters are well passed as data to payzen.