### PR TITLE
fix: check that the order status is PAID

### DIFF
--- a/src/Message/RestDirectPurchaseResponse.php
+++ b/src/Message/RestDirectPurchaseResponse.php
@@ -8,7 +8,7 @@ class RestDirectPurchaseResponse extends RestResponse
      */
     public function isSuccessful()
     {
-        return parent::isSuccessful() && 'SUCCESS' === $this->getData()['status'];
+        return parent::isSuccessful() && 'SUCCESS' === $this->getData()['status'] && $this->checkOrderStatus();
     }
 
     /**
@@ -29,5 +29,15 @@ class RestDirectPurchaseResponse extends RestResponse
             return null;
         }
         return $this->getData()['answer']['orderDetails']['orderId'];
+    }
+
+    private function checkOrderStatus()
+    {
+        $data = $this->getData();
+        if (!isset($data['answer'], $data['answer']['orderStatus'])) {
+            return false;
+        }
+
+        return 'PAID' === $data['answer']['orderStatus'];
     }
 }


### PR DESCRIPTION
The status in the API response only validate that the request body is valid and can be processed. In a case of payment refuse by the bank the status will be SUCCESS. Here we add a check on the orderStatus, to specifictly have the value PAID