### PR TITLE
feat: add metadata parameter

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -118,6 +118,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->getParameter('ownerReference');
     }
 
+    public function setMetadata(array $value)
+    {
+        return $this->setParameter('metadata', $value);
+    }
+
+    public function getMetadata()
+    {
+        return $this->getParameter('metadata');
+    }
+
     public function formatCurrency($amount)
     {
         return (string) intval(strval($amount * 100));

--- a/src/Message/CardCreationResponseInterface.php
+++ b/src/Message/CardCreationResponseInterface.php
@@ -33,4 +33,9 @@ interface CardCreationResponseInterface
      * @return string|null
      */
     public function getOwnerReference();
+
+    /**
+     * @return array
+     */
+    public function getMetadata();
 }

--- a/src/Message/CompleteCardCreationResponse.php
+++ b/src/Message/CompleteCardCreationResponse.php
@@ -11,6 +11,8 @@ class CompleteCardCreationResponse extends AbstractResponse implements CardCreat
 {
     use GetCardInformationTrait;
 
+    use GetMetadataTrait;
+
     public function isSuccessful()
     {
         return $this->getTransactionStatus() == 'ACCEPTED';

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -11,6 +11,8 @@ class CompletePurchaseResponse extends AbstractResponse implements CardCreationR
 {
     use GetCardInformationTrait;
 
+    use GetMetadataTrait;
+
     public function isSuccessful()
     {
         return $this->getTransactionStatus() == 'AUTHORISED';

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -22,6 +22,13 @@ class CreateCardRequest extends AbstractRequest
         $data['vads_version'] = 'V2';
         $data['vads_ext_info_owner_reference'] = $this->getOwnerReference();
 
+        $metadata = $this->getMetadata();
+        if (!empty($metadata)) {
+            foreach ($metadata as $key => $value) {
+                $data['vads_ext_info_' . $key] = $value;
+            }
+        }
+
         if (null !== $this->getNotifyUrl()) {
             $data['vads_url_check'] = $this->getNotifyUrl();
         }

--- a/src/Message/GetMetadataTrait.php
+++ b/src/Message/GetMetadataTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Omnipay\PayZen\Message;
+
+trait GetMetadataTrait
+{
+    /**
+     * @return array
+     */
+    public function getMetadata()
+    {
+        $prefix = 'vads_ext_info_';
+        $metadata = array();
+
+        foreach ($this->data as $key => $value) {
+            if (0 === strpos($key, $prefix)) {
+                $metadata[substr($key, strlen($prefix))] = $value;
+            }
+        }
+
+        return $metadata;
+    }
+}

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -48,6 +48,13 @@ class PurchaseRequest extends AbstractRequest
             $data['vads_cust_email'] = $this->getCard()->getEmail();
         }
 
+        $metadata = $this->getMetadata();
+        if (!empty($metadata)) {
+            foreach ($metadata as $key => $value) {
+                $data['vads_ext_info_' . $key] = $value;
+            }
+        }
+
         if ($this->hasCardReference()) {
             $data['vads_identifier'] = $this->getCardReference();
         }

--- a/tests/Message/CompleteCardCreationResponseTest.php
+++ b/tests/Message/CompleteCardCreationResponseTest.php
@@ -12,6 +12,10 @@ class CompleteCardCreationResponseTest extends TestCase
         $cardNumber = 'asupercardnumber';
         $cardBrand = 'CB';
         $expireAt = new \DateTime('2048-06-30');
+        $metadata = array(
+            'metadata_1' => 'Lorem',
+            'metadata_2' => 'Ipsum'
+        );
         $response = new CompleteCardCreationResponse($this->getMockRequest(), array(
             'signature' => '3132f1e451075f2408cda41f2e647e9b4747d421',
             'vads_amount' => '0',
@@ -38,6 +42,8 @@ class CompleteCardCreationResponseTest extends TestCase
             'vads_trans_id' => 'thetransid',
             'vads_trans_status' => 'ACCEPTED',
             'vads_trans_uuid' => 'thetransuuid',
+            'vads_ext_info_metadata_1' => 'Lorem',
+            'vads_ext_info_metadata_2' => 'Ipsum'
         ));
 
 
@@ -49,5 +55,6 @@ class CompleteCardCreationResponseTest extends TestCase
         $this->assertSame($cardNumber, $response->getCardNumber());
         $this->assertEquals($expireAt, $response->getCardExpiryDate());
         $this->assertSame($cardBrand, $response->getCardBrand());
+        $this->assertSame($metadata, $response->getMetadata());
     }
 }

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -56,7 +56,9 @@ class CompletePurchaseResponseTest extends TestCase
             'vads_action_mode' => 'INTERACTIVE',
             'vads_payment_config' => 'SINGLE',
             'vads_page_action' => 'PAYMENT',
-            'signature' => '3132f1e451075f2408cda41f2e647e9b4747d421',
+            'vads_ext_info_metadata_1' => 'Lorem',
+            'vads_ext_info_metadata_2' => 'Ipsum',
+            'signature' => '3132f1e45107f5f2408cda41f2e647e9b4747d421',
         ));
 
 
@@ -66,5 +68,11 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertSame('454058', $response->getTransactionReference());
         $this->assertSame('20140902094139', $response->getTransactionDate());
+
+        $metadata = array(
+            'metadata_1' => 'Lorem',
+            'metadata_2' => 'Ipsum'
+        );
+        $this->assertSame($metadata, $response->getMetadata());
     }
 }

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -30,6 +30,10 @@ class PurchaseRequestTest extends TestCase
             'errorUrl' => 'http://error',
             'refusedUrl' => 'http://refused',
             'notifyUrl' => 'http://notify',
+            'metadata' => array(
+                'info1' => '1',
+                'info2' => '2'
+            )
         ));
         $data = $this->request->getData();
 
@@ -48,7 +52,9 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://cancel', $data['vads_url_cancel']);
         $this->assertSame('http://error', $data['vads_url_error']);
         $this->assertSame('http://refused', $data['vads_url_refused']);
-        $this->assertSame('e12cdfc3a121c7f49446bab00c98d2072da98633', $data['signature']);
+        $this->assertSame('82f40d72ac5d54be8c94e9e741ad57f136bf08be', $data['signature']);
+        $this->assertSame('1', $data['vads_ext_info_info1']);
+        $this->assertSame('2', $data['vads_ext_info_info2']);
     }
 
     public function testGetRegisterPayData()
@@ -69,6 +75,10 @@ class PurchaseRequestTest extends TestCase
             'notifyUrl' => 'http://notify',
             'createCard' => true,
             'ownerReference' => 'a owner reference',
+            'metadata' => array(
+                'info1' => '1',
+                'info2' => '2'
+            )
         ));
         $data = $this->request->getData();
 
@@ -87,8 +97,10 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://cancel', $data['vads_url_cancel']);
         $this->assertSame('http://error', $data['vads_url_error']);
         $this->assertSame('http://refused', $data['vads_url_refused']);
-        $this->assertSame('7eeb7f33a7fe5631b5327c26118b50a5d04880ee', $data['signature']);
+        $this->assertSame('2a83b1bbd0cd09e01a7e1c8a0beaacff73fa75dd', $data['signature']);
         $this->assertSame('a owner reference', $data['vads_ext_info_owner_reference']);
+        $this->assertSame('1', $data['vads_ext_info_info1']);
+        $this->assertSame('2', $data['vads_ext_info_info2']);
     }
 
     public function testGetRegisterPayWithCardReferenceData()
@@ -109,6 +121,10 @@ class PurchaseRequestTest extends TestCase
             'notifyUrl' => 'http://notify',
             'createCard' => true,
             'cardReference' => 'asuperidentifier',
+            'metadata' => array(
+                'info1' => '1',
+                'info2' => '2'
+            )
         ));
         $data = $this->request->getData();
 
@@ -127,6 +143,8 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('http://cancel', $data['vads_url_cancel']);
         $this->assertSame('http://error', $data['vads_url_error']);
         $this->assertSame('http://refused', $data['vads_url_refused']);
-        $this->assertSame('42180e7e0ef0059611357609f3ae164099c55af7', $data['signature']);
+        $this->assertSame('c112081cb7df1508d3612bcad89bf1003537595d', $data['signature']);
+        $this->assertSame('1', $data['vads_ext_info_info1']);
+        $this->assertSame('2', $data['vads_ext_info_info2']);
     }
 }


### PR DESCRIPTION
Adding a metadata parameter to pass additional arguments and retrieve them after processing with keys vads_ext_info_{key}.  
@see https://payzen.io/fr-FR/form-payment/standard-payment/vads-ext-info.html